### PR TITLE
fixed .format for two-digits year

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "any-date-parser",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "any-date-parser",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "22.15.21",

--- a/src/PatternMatcher/getMatcher.spec.ts
+++ b/src/PatternMatcher/getMatcher.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import defaultLocale from '../data/defaultLocale';
+import getMatcher from './getMatcher';
+
+describe('formatter.format', () => {
+  const matcher = getMatcher(defaultLocale);
+
+  it.each([
+    ['00', 2000],
+    ['51', 2051],
+    ['52', 1952],
+    ['99', 1999],
+    ['1363', 1363],
+    ['2000', 2000],
+  ])('format year: %s => %s', (input: string, expected: number) => {
+    const actual = matcher.formatter({ year: input });
+    expect(actual).toEqual({
+      year: expected,
+    });
+  });
+
+  it.each([
+    ['January', 1],
+    ['Jan', 1],
+    // Default to December if not recognized
+    ['NotAMonth', 12],
+    ['', undefined],
+  ])(
+    'format monthname "%s" => %s',
+    (input: string, expected: number | undefined) => {
+      const actual = matcher.formatter({ monthname: input });
+      expect(actual.month).toBe(expected);
+    }
+  );
+
+  it.each([
+    // 12-hour format with meridiem
+    [{ hour: '12', meridiem: 'AM' }, 0],
+    [{ hour: '12', meridiem: 'PM' }, 12],
+    [{ hour: '01', meridiem: 'AM' }, 1],
+    [{ hour: '11', meridiem: 'PM' }, 23],
+    [{ hour: '00', meridiem: 'AM' }, 0],
+    [{ hour: '00', meridiem: 'PM' }, 12],
+    // 24-hour format (no meridiem)
+    [{ hour: '0' }, 0],
+    [{ hour: '12' }, 12],
+    [{ hour: '23' }, 23],
+    // Invalid meridiem, toInt by default
+    [{ hour: '13', meridiem: 'XX' }, 13],
+    // Missing hour
+    [{ meridiem: 'AM' }, undefined],
+  ])(
+    'format hour %j => %s',
+    (input: Record<string, string>, expected: number | undefined) => {
+      const actual = matcher.formatter(input);
+      expect(actual.hour).toBe(expected);
+    }
+  );
+
+  it.each([
+    ['UTC', 0],
+    ['GMT', 0],
+    ['ACT', 480],
+    ['Central Standard Time', -360],
+    ['invalidZone', undefined],
+    ['', undefined],
+  ])('format zone "%s" => %s', (input: string, expected: number) => {
+    const actual = matcher.formatter({ zone: input });
+    expect(actual.offset).toBe(expected);
+  });
+
+  it.each([
+    ['+02:00', 120],
+    ['-05:30', -330],
+    ['+00:00', 0],
+    ['+0000', 0],
+    ['-0100', -60],
+    ['+14:00', 840],
+    ['-12:00', -720],
+    ['+2', 120],
+    ['-3', -180],
+    ['Z', 0],
+    ['invalid', 0],
+    ['', 0],
+    [undefined, undefined],
+  ])(
+    'format offset "%s" => %s',
+    (input: string | undefined, expected: number | undefined) => {
+      const actual = matcher.formatter({ offset: input });
+      expect(actual.offset).toBe(expected);
+    }
+  );
+
+  it.each([
+    ['0', 0],
+    ['001', 1],
+    ['123', 123],
+    ['999', 999],
+    [undefined, undefined],
+  ])(
+    'format millisecond "%s" => %s',
+    (input: string | undefined, expected: number | undefined) => {
+      const actual = matcher.formatter({ millisecond: input });
+      expect(actual.millisecond).toBe(expected);
+    }
+  );
+
+  it('format all fields', () => {
+    const actual = matcher.formatter({
+      year: '2020',
+      month: '12',
+      day: '31',
+      hour: '23',
+      minute: '59',
+      second: '58',
+      millisecond: '999',
+      offset: '+01:00',
+    });
+    expect(actual).toEqual({
+      year: 2020,
+      month: 12,
+      day: 31,
+      hour: 23,
+      minute: 59,
+      second: 58,
+      millisecond: 999,
+      offset: 60,
+    });
+  });
+
+  it('format year for Buddhist calendar', () => {
+    const matcherBuddhist = getMatcher('th-TH');
+    const actual = matcherBuddhist.formatter({ year: '2566' });
+    expect(actual.year).toBe(2023);
+  });
+});

--- a/src/PatternMatcher/getMatcher.ts
+++ b/src/PatternMatcher/getMatcher.ts
@@ -124,7 +124,7 @@ function getFormatter(helper: LocaleHelper) {
       }
     }
     if (result.year < 100) {
-      result.year = twoDigitYears[result.year];
+      result.year = twoDigitYears[extracted.year];
     }
     if (result.year && helper.dateOptions.calendar === 'buddhist') {
       result.year -= 543;

--- a/src/data/twoDigitYears.ts
+++ b/src/data/twoDigitYears.ts
@@ -1,6 +1,6 @@
 // 2-digit years: 1951 through 2050
 const twoDigitYears = {};
-for (let i = 1; i < 100; i++) {
+for (let i = 0; i < 100; i++) {
   const key = (i <= 9 ? '0' : '') + i;
   twoDigitYears[key] = i + (i > 51 ? 1900 : 2000);
 }


### PR DESCRIPTION
Hello,

I have found an issue with .format for the two-digit year.
It doesn't work correctly because `result.year` is used as a key in the `twoDigitYears` dict instead of `extracted.year`.

`getMatcher(defaultLocale).formatter({ year: "02" }) => { year: undefined }`
